### PR TITLE
feat: groups support

### DIFF
--- a/src/components/CreateDialog/index.tsx
+++ b/src/components/CreateDialog/index.tsx
@@ -5,6 +5,7 @@ import TextField from 'material-ui/TextField';
 import * as moment from 'moment';
 import PercentageSelect from '../Inputs/PercentageSelect';
 import Users from '../Inputs/Users/';
+import Groups from '../Inputs/Groups/';
 import './CreateDialog.scss';
 import { Action } from 'redux';
 import {Feature, IFeature} from '../../models/Feature';
@@ -17,6 +18,7 @@ interface CreateDialogProps {
 
 interface CreateDialogState {
     users?: number[];
+    groups?: string[];
     errors?: {
         [key: string]: string;
     };
@@ -31,9 +33,11 @@ class CreateDialog extends React.Component<CreateDialogProps, CreateDialogState>
 
     constructor(props: any) {
       super(props);
-      this.state = { users: [], errors: {}, inputs: {name: ''} };
+      this.state = { users: [], groups: [], errors: {}, inputs: {name: ''} };
       this.removeUser = this.removeUser.bind(this);
       this.addUser = this.addUser.bind(this);
+      this.removeGroup = this.removeGroup.bind(this);
+      this.addGroup = this.addGroup.bind(this);
       this.updateInput = this.updateInput.bind(this);
     }
 
@@ -56,7 +60,7 @@ class CreateDialog extends React.Component<CreateDialogProps, CreateDialogState>
     }
 
     public createFeature(): Feature {
-        const options: IFeature = Object.assign({}, this.state.inputs, {users: this.state.users});
+        const options: IFeature = Object.assign({}, this.state.inputs, {users: this.state.users, groups: this.state.groups});
         return new Feature(options);
     }
 
@@ -130,6 +134,7 @@ class CreateDialog extends React.Component<CreateDialogProps, CreateDialogState>
           </div>
 
           <Users users={this.state.users} onAdd={this.addUser} onDelete={this.removeUser}  />
+          <Groups groups={this.state.groups} onAdd={this.addGroup} onDelete={this.removeGroup}  />
 
       </Dialog>)
   }
@@ -145,6 +150,19 @@ class CreateDialog extends React.Component<CreateDialogProps, CreateDialogState>
 
         users.push(userID);
         this.setState({users});
+    }
+
+    private removeGroup(name: any): void {
+        const groups = this.state.groups.filter((group) => group !== name );
+        this.setState({groups});
+    }
+
+    private addGroup(name: any) {
+        const groups  = this.state.groups;
+        if (groups.filter((groups) => groups === name ).length) { return; }
+
+        groups.push(name);
+        this.setState({groups});
     }
 
     private updateInput(inputName: string, inputValue: string|number) {

--- a/src/components/EditDialog/index.tsx
+++ b/src/components/EditDialog/index.tsx
@@ -3,6 +3,7 @@ import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 import TextField from 'material-ui/TextField';
 import Users from '../Inputs/Users/index';
+import Groups from '../Inputs/Groups/index';
 import PercentageSelect from '../Inputs/PercentageSelect';
 import * as moment from 'moment';
 import './EditDialog.scss';
@@ -32,6 +33,8 @@ class EditDialog extends React.Component<EditDialogProps, EditDialogState> {
         super(props);
         this.removeUser = this.removeUser.bind(this);
         this.addUser = this.addUser.bind(this);
+        this.removeGroup = this.removeGroup.bind(this);
+        this.addGroup = this.addGroup.bind(this);
         this.updateFeature = this.updateFeature.bind(this);
     }
 
@@ -119,6 +122,7 @@ class EditDialog extends React.Component<EditDialogProps, EditDialogState> {
                 />
 
                 <Users users={feature.users} onAdd={this.addUser} onDelete={this.removeUser} />
+                <Groups groups={feature.groups} onAdd={this.addGroup} onDelete={this.removeGroup} />
             </div>
 
         </Dialog>);
@@ -134,7 +138,18 @@ class EditDialog extends React.Component<EditDialogProps, EditDialogState> {
         this.updateFeature('users', users.concat(userID));
     }
 
-    private updateFeature(inputName: string, inputValue: string | number| number[]) {
+    private removeGroup(name: string) {
+        const groups  = this.props.feature.groups.filter((group) => group !== name );
+        this.updateFeature('groups', groups);
+    }
+
+    private addGroup(name: string) {
+        const groups  = this.props.feature.groups;
+        if (groups.filter((group) => group === name ).length) { return; }
+        this.updateFeature('groups', groups.concat(name));
+    }
+
+    private updateFeature(inputName: string, inputValue: string | number | number[] | string[]) {
         this.props.updateFeature(inputName, inputValue);
     }
 

--- a/src/components/Features/index.tsx
+++ b/src/components/Features/index.tsx
@@ -161,6 +161,28 @@ class Features extends React.Component<FeaturesProps, FeaturesState> {
 
 
                         <Column fixed={true}
+                                width={80}
+                                header={<Cell className="standard-text">Groups</Cell>}
+                                cell={({rowIndex}) => (
+                                    <Cell>
+                                        {<IconMenu
+                                            maxHeight={300}
+                                            width={100}
+                                            useLayerForClickAway={true}
+                                            iconButtonElement={<IconButton disabled={!sortedFeatures[rowIndex].groups.length} iconStyle={{color: green500}}> <FontIcon
+                                                className="material-icons">supervisor_account</FontIcon></IconButton>}>
+                                            {
+                                                sortedFeatures[rowIndex].groups.length ?
+
+                                                sortedFeatures[rowIndex].groups.map((group) => <MenuItem key={`${sortedFeatures[rowIndex].name}_${group}`} value={1}
+                                                                                                                primaryText={group}/>) :
+                                                    <MenuItem primaryText={"No groups"}/>
+                                            }
+                                        </IconMenu>}
+                                    </Cell>
+                                )} />
+
+                        <Column fixed={true}
                                 width={100}
                                 header={<Cell className="standard-text">Percentage</Cell>}
                                 cell={({rowIndex}) => (

--- a/src/components/Inputs/Groups/Groups.scss
+++ b/src/components/Inputs/Groups/Groups.scss
@@ -1,0 +1,12 @@
+.chips-container {
+    clear: both;
+
+    h1 {
+        margin: 0;
+    }
+
+    .add-groups {
+        float: left;
+        margin-right: 5px !important;
+    }
+}

--- a/src/components/Inputs/Groups/index.tsx
+++ b/src/components/Inputs/Groups/index.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import './Groups.scss';
+import TextField from 'material-ui/TextField';
+import Chip from 'material-ui/Chip';
+
+interface GroupsProps {
+    groups: string[];
+    onAdd: (group: string) => void;
+    onDelete: (group: string) => void;
+}
+
+const Groups = (props: GroupsProps) => {
+    return(
+        <div className="chips-container">
+            <TextField
+                className="add-groups"
+                fullWidth={true}
+                floatingLabelText="Groups:"
+                hintText="Enter group name and press enter:"
+                floatingLabelFixed={true}
+                onKeyDown={(event) => {
+                    if (event.keyCode !== 13) { return; }
+
+                    props.onAdd(event.target.value);
+                    event.target.value = '';
+                }}
+            />
+            {props.groups.map((group: string) => <Chip className="group"
+                                                     key={group}
+                                                     onRequestDelete={() => { props.onDelete(group); }}> {group} </Chip>)}
+        </div>
+    );
+};
+
+export default Groups;
+

--- a/src/models/Feature.ts
+++ b/src/models/Feature.ts
@@ -4,6 +4,7 @@ export interface IFeature {
     name: string;
     history?: Array<{updated_at: string, author_mail: string, percentage: number, author: string}>;
     users?: number[];
+    groups?: string[];
     description?: string;
     author?: string;
     author_mail?: string;
@@ -15,6 +16,7 @@ export class Feature {
 
     public history: any[];
     public users: any[];
+    public groups: any[];
     public description: string;
     public author: string;
     public authorMail: string;
@@ -26,6 +28,7 @@ export class Feature {
     public constructor(payload: IFeature) {
         this.description = payload.description || '';
         this.users = payload.users || [];
+        this.groups = payload.groups || [];
         this.authorMail = payload.author_mail || '';
         this.author = payload.author || '';
         this.createdAt = payload.created_at || '';


### PR DESCRIPTION
Support for [existing] user groups. This was needed in our case because our existing rollout integration is groups based. So this change allows to assign feature to group but doesn't deal with groups membership - membership can be edited via ruby console as before.

Depends on https://github.com/fiverr/rollout_service/pull/8